### PR TITLE
Remuevo closing tag sobrante

### DIFF
--- a/compras.html
+++ b/compras.html
@@ -13,7 +13,6 @@
       content="width=device-width, initial-scale=1, user-scalable=no"
       charset="UTF-8"
     />
-    />
     <link rel="stylesheet" href="assets/css/main.css" />
     <noscript
       ><link rel="stylesheet" href="assets/css/noscript.css"

--- a/kidney.html
+++ b/kidney.html
@@ -13,7 +13,6 @@
       content="width=device-width, initial-scale=1, user-scalable=no"
       charset="UTF-8"
     />
-    />
     <link rel="stylesheet" href="assets/css/main.css" />
     <noscript
       ><link rel="stylesheet" href="assets/css/noscript.css"


### PR DESCRIPTION
`kidney.html` y `compras.html` tienen un closing tag de más, que se termina renderizando como texto plano. Esto causa que el header de las dos páginas tenga detrás el texto "/>" 👀:

<img width="292" alt="image" src="https://github.com/nicolaspavon/equipodos.github.io/assets/47277080/79e4de57-4e20-4381-bfeb-9b9a9f15e1ad">

Con el fix, el texto detrás desaparece:

<img width="173" alt="image" src="https://github.com/nicolaspavon/equipodos.github.io/assets/47277080/dcc7c81f-0fb4-43c9-83a1-382ade58ebba">

Detalle mínimo del cual algunas personas pueden darse cuenta. 😁