### PR TITLE
Agrego pie de página reutilizable y remuevo copyright

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <section id="footer">
+    <div class="inner">
+      <ul class="copyright">
+        <li>Diseño: <a href="http://html5up.net">HTML5 UP</a></li>
+      </ul>
+    </div>
+  </section>
+</html>

--- a/compras.html
+++ b/compras.html
@@ -190,14 +190,8 @@
       </section>
 
       <!-- Footer -->
-      <section id="footer">
-        <div class="inner">
-          <ul class="copyright">
-            <li>&copy; Nicolás Pavón Inc. All rights reserved.</li>
-            <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-          </ul>
-        </div>
-      </section>
+      <div id="footer"></div>
+      <script src="/scripts/footer.js"></script>
     </div>
 
     <!-- Scripts -->

--- a/data_cleaning.html
+++ b/data_cleaning.html
@@ -66,14 +66,8 @@
       </section>
 
       <!-- Footer -->
-      <section id="footer">
-        <div class="inner">
-          <ul class="copyright">
-            <li>&copy; Nicolás Pavón Inc. All rights reserved.</li>
-            <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-          </ul>
-        </div>
-      </section>
+      <div id="footer"></div>
+      <script src="/scripts/footer.js"></script>
     </div>
 
     <!-- Scripts -->

--- a/index.html
+++ b/index.html
@@ -278,14 +278,8 @@
       </section>
 
       <!-- Footer -->
-      <section id="footer">
-        <div class="inner">
-          <ul class="copyright">
-            <li>&copy; Nicolás Pavón. All rights reserved.</li>
-            <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-          </ul>
-        </div>
-      </section>
+      <div id="footer"></div>
+      <script src="/scripts/footer.js"></script>
     </div>
 
     <!-- Scripts -->

--- a/kidney.html
+++ b/kidney.html
@@ -645,14 +645,8 @@
       </section>
 
       <!-- Footer -->
-      <section id="footer">
-        <div class="inner">
-          <ul class="copyright">
-            <li>&copy; Nicolás Pavón Inc. All rights reserved.</li>
-            <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-          </ul>
-        </div>
-      </section>
+      <div id="footer"></div>
+      <script src="/scripts/footer.js"></script>
     </div>
 
     <!-- Scripts -->

--- a/scripts/footer.js
+++ b/scripts/footer.js
@@ -1,0 +1,6 @@
+const container = document.getElementById("footer");
+fetch("/components/footer.html")
+  .then((response) => response.text())
+  .then((content) => {
+    container.innerHTML = content;
+  });

--- a/supervivientes_titanic.html
+++ b/supervivientes_titanic.html
@@ -1920,14 +1920,8 @@ model_performance.sort_values(by="Accuracy", ascending=False)
       </section>
 
       <!-- Footer -->
-      <section id="footer">
-        <div class="inner">
-          <ul class="copyright">
-            <li>&copy; Nicolás Pavón Inc. All rights reserved.</li>
-            <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-          </ul>
-        </div>
-      </section>
+      <div id="footer"></div>
+      <script src="/scripts/footer.js"></script>
     </div>
 
     <!-- Scripts -->


### PR DESCRIPTION
Soluciona #3. Agrego un componente footer reutilizable para cualquier página, para forzar a tener un único footer con un único estilo y reemplazo el actual en todas las pantallas por este componente. Se ve así:

<img width="1440" alt="image" src="https://github.com/nicolaspavon/equipodos.github.io/assets/47277080/70cc80e6-1efd-45d7-a69b-6a279f474ff8">
